### PR TITLE
add extension grpc and sockets

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -28,14 +28,20 @@ RUN apt-get upgrade && apt-get update && ACCEPT_EULA=Y && apt-get install -y \
         gnupg2 \
         zip \
         git \
+        gcc \
+        g++ \
+        autoconf \
+        libc-dev \
+        pkg-config \ 
     && pecl install redis \
     && pecl install geoip-1.1.1 \
     && pecl install apcu \
     && pecl install memcached \
     && pecl install timezonedb \
+    && pecl install grpc \
     && docker-php-ext-configure gd --with-gd --with-freetype-dir=/usr/include/ --with-webp-dir=/usr/include/ --with-jpeg-dir=/usr/include/  \
     && docker-php-ext-configure zip --with-libzip \
-    && docker-php-ext-install gd calendar gmp ldap sysvmsg pcntl iconv bcmath xml mbstring pdo tidy gettext intl pdo_mysql mysqli simplexml xml xsl xmlwriter zip opcache exif \
+    && docker-php-ext-install gd calendar gmp ldap sysvmsg pcntl iconv bcmath xml mbstring pdo tidy gettext intl pdo_mysql mysqli simplexml xml xsl xmlwriter zip opcache exif sockets \
     && docker-php-ext-enable redis geoip apcu memcached timezonedb \
     && printf "log_errors = On \nerror_log = /dev/stderr\n" > /usr/local/etc/php/conf.d/php-logs.ini
 

--- a/README.md
+++ b/README.md
@@ -104,6 +104,7 @@ The following modules / extensions / PECLs are enabled on this container (exclud
 * pdo_mysql 
 * mysqli 
 * simplexml 
+* sockets
 * tokenizer 
 * xml 
 * xmlwriter 
@@ -112,6 +113,7 @@ The following modules / extensions / PECLs are enabled on this container (exclud
 #### PECLs
 * Redis
 * GeoIP
+* gRPC
 * Memcached
 * TimezoneDB
 * APCu

--- a/etc/php/development.ini
+++ b/etc/php/development.ini
@@ -27,6 +27,9 @@ date.timezone = Europe/London
 mysql.default_host = mysql
 mysqli.default_host = mysql
 
+; Enable extension
+extension = grpc.so
+
 ; Zend OPCache
 opcache.enable = 0
 opcache.memory_consumption = 256

--- a/etc/php/production.ini
+++ b/etc/php/production.ini
@@ -27,6 +27,9 @@ date.timezone = Europe/London
 mysql.default_host = mysql
 mysqli.default_host = mysql
 
+; Enable extension
+extension = grpc.so
+
 ; Zend OPCache
 opcache.enable = 1
 opcache.memory_consumption = 128


### PR DESCRIPTION
add gRPC Remote Procedure Calls and socket extension, the test can be done through the [file](https://gist.githubusercontent.com/md5/f0ca3ba1c2b0f04785fb/raw/1406f971b80c785a1092bb5f82dc93e2b7cf96bd/test.php), developed by [@md5](https://gist.github.com/md5).